### PR TITLE
use call to insure all arguments are passed

### DIFF
--- a/ul_amd.js
+++ b/ul_amd.js
@@ -54,7 +54,7 @@ THE SOFTWARE.
   root['use_module'] = function (dependencies, callback) {
     if (typeof callback != function_type) throw callback_error;
     satisfy_dependencies(dependencies).then(function (dependencies_actual) {
-      callback.apply(root, dependencies_actual);
+      callback.call(root, dependencies_actual);
     });
   }
 


### PR DESCRIPTION
Not sure how this could work as is...  The callback on line 81 wants a single argument... and then it again tries to `apply` it... I could only get this to work if I changed this to a `call` (as I have done in this PR) or if I changed line 81 to use the new `...args` syntax so that it accepted the FULL list of arguments trying to be passed here and then turned around and passed them on.

Without any changes only the first argument makes it to line 81 and then line 82 can't possibly work properly with the apply since you only have one argument. 

Am I missing something?